### PR TITLE
Added front end variable to test environment

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -45,4 +45,6 @@ Rails.application.configure do
 
   # Raises error for missing translations.
   # config.action_view.raise_on_missing_translations = true
+
+  config.front_end_origin = 'localhost:3001'
 end


### PR DESCRIPTION
Just a small addition to the testing config to make tests runnable again. Previously never added in the front end variable in the test environment when first setup.